### PR TITLE
feat(textlint-rule-spacing): add `exceptPunctuation` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-register": "^6.9.0",
     "lerna": "2.0.0-beta.24",
-    "mocha": "^2.5.3"
+    "mocha": "^3.1.0"
   },
   "scripts": {
     "bootstrap": "lerna bootstrap",

--- a/packages/textlint-rule-ja-space-between-half-and-full-width/README.md
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/README.md
@@ -9,6 +9,10 @@
     OK: これはUnicode
     NG: これは Unicode
 
+全角文字には、句読点（、。）も含まれていますがデフォルトでは、`exceptPunctuation: true`であるため無視されます。
+
+    OK: これも、Unicode。
+
 ## Install
 
 Install with [npm](https://www.npmjs.com/):
@@ -41,6 +45,9 @@ textlint --rule ja-space-between-half-and-full-width README.md
 - `space`: `"always"` || `"never"`
     - デフォルト: `"never"`
     - スペースを常に 入れる(`"always"`) or 入れない(`"never"`)
+- `exceptPunctuation`: `boolean`
+    - デフォルト: `true`
+    - 句読点（、。）を例外として扱うかどうか
     
 ```json
 {
@@ -51,6 +58,25 @@ textlint --rule ja-space-between-half-and-full-width README.md
     }
 }
 ```   
+
+`exceptPunctuation: true`とした場合は、句読点に関しては無視されるようになります。
+
+スペースは必須だが、`日本語、[alphabet]。`は許可する
+
+        text: "これは、Exception。",
+        options: {
+            space: "always",
+            exceptPunctuation: true
+        }
+
+スペースは不要だが、`日本語、 [alphabet] 。`は許可する。
+
+        text: "これは、 Exception 。",
+        options: {
+            space: "never",
+            exceptPunctuation: true
+        }
+        
 
 ## Changelog
 

--- a/packages/textlint-rule-ja-space-between-half-and-full-width/test/index-test.js
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/test/index-test.js
@@ -5,8 +5,9 @@ import rule from "../src/index";
 var tester = new TextLintTester();
 tester.run("全角文字と半角文字の間", rule, {
     valid: [
-        // never
+        // デフォルト: never && exceptPunctuation
         "JTF標準",
+        "これも、OK。",
         {
             text: "JTF標準",
             options: {
@@ -42,6 +43,37 @@ Pull Request、コミットのやりかたなどが書かれています。`,
             options: {
                 space: "never"
             },
+        },
+        // except
+        {
+            text: "Always これは、Exception。",
+            options: {
+                space: "always",
+                exceptPunctuation: true
+            },
+        },
+        // 入れても良い
+        {
+            text: "Always これは 、 Exception 。",
+            options: {
+                space: "always",
+                exceptPunctuation: true
+            },
+        },
+        {
+            text: "Never:これは、 Exception 。",
+            options: {
+                space: "never",
+                exceptPunctuation: true
+            }
+        },
+        // 入れても良い
+        {
+            text: "Never:これは、Exception。",
+            options: {
+                space: "never",
+                exceptPunctuation: true
+            }
         },
     ],
     invalid: [
@@ -82,6 +114,33 @@ Pull Request、コミットのやりかたなどが書かれています。`,
                 {message: "原則として、全角文字と半角文字の間にスペースを入れません。"}
             ]
         },
+        {
+
+            text: "aaa と bbb 、 ccc と ddd",
+            output: "aaaとbbb 、 cccとddd",
+            options: {
+                space: "never",
+                exceptPunctuation: true
+            },
+            errors: [
+                {
+                    message: "原則として、全角文字と半角文字の間にスペースを入れません。",
+                    column: 4
+                },
+                {
+                    message: "原則として、全角文字と半角文字の間にスペースを入れません。",
+                    column: 6
+                },
+                {
+                    message: "原則として、全角文字と半角文字の間にスペースを入れません。",
+                    column: 16
+                },
+                {
+                    message: "原則として、全角文字と半角文字の間にスペースを入れません。",
+                    column: 18
+                }
+            ]
+        },
         // need space
         {
             text: "JTF標準",
@@ -93,6 +152,24 @@ Pull Request、コミットのやりかたなどが書かれています。`,
                 {
                     message: "原則として、全角文字と半角文字の間にスペースを入れます。",
                     column: 3
+                }
+            ]
+        },
+        {
+            text: "aaa、bbb",
+            output: "aaa 、 bbb",
+            options: {
+                space: "always",
+                exceptPunctuation: false
+            },
+            errors: [
+                {
+                    message: "原則として、全角文字と半角文字の間にスペースを入れます。",
+                    column: 3
+                },
+                {
+                    message: "原則として、全角文字と半角文字の間にスペースを入れます。",
+                    column: 4
                 }
             ]
         },
@@ -123,6 +200,33 @@ Pull Request、コミットのやりかたなどが書かれています。`,
                 {
                     message: "原則として、全角文字と半角文字の間にスペースを入れます。",
                     column: 11
+                }
+            ]
+        },
+        // with option
+        {
+            text: "aaaとbbb、cccとddd",
+            output: "aaa と bbb、ccc と ddd",
+            options: {
+                space: "always",
+                exceptPunctuation: true
+            },
+            errors: [
+                {
+                    message: "原則として、全角文字と半角文字の間にスペースを入れます。",
+                    column: 3
+                },
+                {
+                    message: "原則として、全角文字と半角文字の間にスペースを入れます。",
+                    column: 4
+                },
+                {
+                    message: "原則として、全角文字と半角文字の間にスペースを入れます。",
+                    column: 11
+                },
+                {
+                    message: "原則として、全角文字と半角文字の間にスペースを入れます。",
+                    column: 12
                 }
             ]
         },


### PR DESCRIPTION
句読点（、。）を例外として扱うかどうかのオプションを追加
"句読点と英単語の間はスペース入れないルール"もこれで満たせる。
(always && exceptPunctuation: true)

デフォルトの挙動を変更
(never && exceptPunctuation: true)

close #11